### PR TITLE
fix envtest startup

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -71,8 +71,11 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
+	srv := testEnv.ControlPlane.GetAPIServer()
+	srv.Configure().Set("bind-address", "127.0.0.1")
+	srv.Configure().Set("advertise-address", "127.0.0.1")
 
 	var err error
 	// cfg is defined in this file globally.


### PR DESCRIPTION
## Summary
- make kube-apiserver bind to explicit localhost address in test suite
- use the same envtest version as Makefile

## Testing
- `make fmt`
- `make vet`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860df287d5c832a9775935819002af3